### PR TITLE
Path.sep on Windows will fail to resolve SQL files as expected

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,7 +20,7 @@ export function parseFiles(root_directories: string[]): T.SqlFile[] {
             const path = Path.parse(relative_path)
 
             const file_contents = Fs.readFileSync(f, 'utf8')
-            const path_parts = _.compact(path.dir.split(Path.sep).concat(path.name))
+            const path_parts = _.compact(path.dir.split('/').concat(path.name))
             const sql_name = path_parts.join('_')
             const sql_key = path_parts.join('.')
 


### PR DESCRIPTION
With the code as it was before .sql('foo.bar.baz') will fail on Windows and you will be required to say .sql('foo/bar.baz') instead to find a baz.sql inside root_dir/foo/bar

Since Path.parse() will return with / as the delimiter even on Windows you should be able to just say / in all cases.
